### PR TITLE
Typo in 1695. There is no such function _animate.

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1692,7 +1692,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 			}
 
 			if (this.options.group.revertClone) {
-				this._animate(dragEl, cloneEl);
+				this.animate(dragEl, cloneEl);
 			}
 
 			css(cloneEl, 'display', '');


### PR DESCRIPTION
The _animate function doesn't exist. Replaced with call to animate.